### PR TITLE
COMM-542 Fix issue with scope claims handling on RefreshTokenStore

### DIFF
--- a/src/Core.Nhibernate.IntegrationTests/ObjectCreator.cs
+++ b/src/Core.Nhibernate.IntegrationTests/ObjectCreator.cs
@@ -98,7 +98,10 @@ namespace Core.Nhibernate.IntegrationTests
                 .Without(t => t.Client)
                 .With(t => t.Claims, new List<Claim>()
                 {
-                    new Claim(Constants.ClaimTypes.Subject, subjectId ?? Guid.NewGuid().ToString())
+                    new Claim(Constants.ClaimTypes.Subject, subjectId ?? Guid.NewGuid().ToString()),
+                    new Claim(Constants.ClaimTypes.Scope, AFixture.Create<string>()),
+                    new Claim(Constants.ClaimTypes.Scope, AFixture.Create<string>()),
+                    new Claim(Constants.ClaimTypes.Scope, AFixture.Create<string>())
                 });
 
             var token = tokenBuilder.Create();

--- a/src/Core.Nhibernate.IntegrationTests/Stores/AuthorizationCodeStoreTests.cs
+++ b/src/Core.Nhibernate.IntegrationTests/Stores/AuthorizationCodeStoreTests.cs
@@ -97,8 +97,7 @@ namespace Core.Nhibernate.IntegrationTests.Stores
                 code.CodeChallenge,
                 code.CodeChallengeMethod,
                 code.SubjectId,
-                code.ClientId,
-                Scopes = code.Scopes.Select(x => x)
+                code.ClientId
             };
 
             return JsonConvert.SerializeObject(obj);

--- a/src/Core.Nhibernate.IntegrationTests/Stores/RefreshTokenStoreTests.cs
+++ b/src/Core.Nhibernate.IntegrationTests/Stores/RefreshTokenStoreTests.cs
@@ -77,7 +77,6 @@ namespace Core.Nhibernate.IntegrationTests.Stores
         {
             var obj = new
             {
-                code.ClientId,
                 CreationTime = code.CreationTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFFzzz"),
                 code.LifeTime,
                 AccessToken = new
@@ -92,19 +91,14 @@ namespace Core.Nhibernate.IntegrationTests.Stores
                         code.ClientId
                     },
                     Claims = code.AccessToken.Claims.Select(x => new { x.Type, x.Value }),
-                    code.AccessToken.Version,
-                    code.SubjectId,
-                    code.ClientId,
-                    Scopes = code.AccessToken.Scopes.Select(x => x),
+                    code.AccessToken.Version
                 },
                 Subject = new
                 {
                     code.Subject.Identity.AuthenticationType,
                     Claims = code.Subject.Claims.Select(x => new { x.Type, x.Value }),
                 },
-                code.Version,
-                code.SubjectId,
-                Scopes = code.Scopes.Select(x => x)
+                code.Version
             };
 
             return JsonConvert.SerializeObject(obj);

--- a/src/Core.Nhibernate.IntegrationTests/Stores/TokenHandleStoreTests.cs
+++ b/src/Core.Nhibernate.IntegrationTests/Stores/TokenHandleStoreTests.cs
@@ -64,11 +64,7 @@ namespace Core.Nhibernate.IntegrationTests.Stores
                     code.ClientId
                 },
                 Claims = code.Claims.Select(x => new { x.Type, x.Value }),
-                code.Version,
-                code.SubjectId,
-                code.ClientId,
-                Scopes = code.Scopes.Select(x => x),
-
+                code.Version
             };
 
             return JsonConvert.SerializeObject(obj);

--- a/src/Core.Nhibernate/Models/AuthorizationCode.cs
+++ b/src/Core.Nhibernate/Models/AuthorizationCode.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace IdentityServer3.Contrib.Nhibernate.Models
 {
@@ -73,10 +72,5 @@ namespace IdentityServer3.Contrib.Nhibernate.Models
         /// Gets or sets the client identifier.
         /// </summary>
         public string ClientId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the scopes.
-        /// </summary>
-        public IEnumerable<string> Scopes => RequestedScopes.Select(x => x.Name);
     }
 }

--- a/src/Core.Nhibernate/Models/RefreshToken.cs
+++ b/src/Core.Nhibernate/Models/RefreshToken.cs
@@ -1,16 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace IdentityServer3.Contrib.Nhibernate.Models
 {
     internal class RefreshToken
     {
-        /// <summary>
-        /// Gets or sets the ClientId
-        /// </summary>
-        public string ClientId => AccessToken.ClientId;
-
         /// <summary>
         /// Gets or sets the creation time.
         /// </summary>
@@ -35,15 +28,5 @@ namespace IdentityServer3.Contrib.Nhibernate.Models
         /// Gets or sets the version number.
         /// </summary>
         public int Version { get; set; }
-
-        /// <summary>
-        /// Gets the subject identifier.
-        /// </summary>
-        public string SubjectId => AccessToken.SubjectId;
-
-        /// <summary>
-        /// Gets the scopes
-        /// </summary>
-        public IEnumerable<string> Scopes => AccessToken.Scopes.Select(x => x.Name);
     }
 }

--- a/src/Core.Nhibernate/Models/Token.cs
+++ b/src/Core.Nhibernate/Models/Token.cs
@@ -13,8 +13,5 @@ namespace IdentityServer3.Contrib.Nhibernate.Models
         public ClientLite Client { get; set; }
         public IEnumerable<ClaimLite> Claims { get; set; }
         public int Version { get; set; }
-        public string SubjectId { get; set; }
-        public string ClientId { get; set; }
-        public IEnumerable<ScopeLite> Scopes { get; set; }
     }
 }

--- a/src/Core.Nhibernate/Profiles/EntitiesProfile.cs
+++ b/src/Core.Nhibernate/Profiles/EntitiesProfile.cs
@@ -84,8 +84,7 @@ namespace IdentityServer3.Contrib.Nhibernate.Profiles
 
             CreateMap<CoreModels.RefreshToken, Entities.Token>();
 
-            CreateMap<CoreModels.AuthorizationCode, ContribModels.AuthorizationCode>()
-                .ForMember(dest => dest.Scopes, opt => opt.Ignore());
+            CreateMap<CoreModels.AuthorizationCode, ContribModels.AuthorizationCode>();
 
             CreateMap<Claim, ContribModels.ClaimLite>();
 
@@ -97,8 +96,7 @@ namespace IdentityServer3.Contrib.Nhibernate.Profiles
 
             CreateMap<CoreModels.Scope, ContribModels.ScopeLite>();
 
-            CreateMap<CoreModels.RefreshToken, ContribModels.RefreshToken>()
-                .ForMember(dest => dest.Scopes, opt => opt.Ignore());
+            CreateMap<CoreModels.RefreshToken, ContribModels.RefreshToken>();
 
             CreateMap<CoreModels.Token, ContribModels.Token>();
 
@@ -114,15 +112,13 @@ namespace IdentityServer3.Contrib.Nhibernate.Profiles
                     opt => opt.MapFrom(src => GetClaims(src.Claims)));
 
             CreateMap<ContribModels.RefreshToken, CoreModels.RefreshToken>()
-                .ForMember(dest => dest.Scopes, opt => opt.Ignore())
                 .ForMember(dest => dest.Subject,
                     opt => opt.MapFrom(src => GetClaimsPrincipal(src.Subject)));
 
             CreateMap<ContribModels.Token, CoreModels.Token>()
                 .ForMember(dest => dest.Client, opt => opt.Ignore())
                 .ForMember(dest => dest.Claims,
-                    opt => opt.MapFrom(src => GetClaims(src.Claims)))
-                .ForMember(dest => dest.Scopes, opt => opt.Ignore());
+                    opt => opt.MapFrom(src => GetClaims(src.Claims)));
         }
 
         private IEnumerable<Claim> GetClaims(IEnumerable<ContribModels.ClaimLite> claims)

--- a/src/Core.Nhibernate/Stores/RefreshTokenStore.cs
+++ b/src/Core.Nhibernate/Stores/RefreshTokenStore.cs
@@ -97,7 +97,8 @@ namespace IdentityServer3.Contrib.Nhibernate.Stores
 
             if (refreshToken == null) { return null; }
 
-            refreshToken.AccessToken.Client = await ClientStore.FindClientByIdAsync(nhibRefreshToken.ClientId);
+            refreshToken.AccessToken.Client = await ClientStore
+                .FindClientByIdAsync(nhibRefreshToken.AccessToken.Client.ClientId);
 
             var claims = nhibRefreshToken.Subject.Claims.Select(x => new Claim(x.Type, x.Value));
             refreshToken.Subject = new ClaimsPrincipal(

--- a/src/Core.Nhibernate/Stores/TokenHandleStore.cs
+++ b/src/Core.Nhibernate/Stores/TokenHandleStore.cs
@@ -74,7 +74,7 @@ namespace IdentityServer3.Contrib.Nhibernate.Stores
             if (tokenModel == null) { return null; }
 
             var clientEntity = await session.Query<ClientEntity>()
-                .SingleOrDefaultAsync(x => x.ClientId == nhibTokenModel.ClientId);
+                .SingleOrDefaultAsync(x => x.ClientId == nhibTokenModel.Client.ClientId);
 
             tokenModel.Client = clientEntity == null ? null : _mapper.Map<CoreClientModel>(clientEntity);
 


### PR DESCRIPTION
- Have fixed an issue with the way scopes claims were being handled, upgrade didn't test this correctly and values were not able to deserialise. Now fixed.
- Have simplified serialisation models to remove duplicate fields. There was quite a bit of data being serialised multiple times due to layering. This has now been streamlined.